### PR TITLE
Remove AbstractBlockchainExplorer dependency from TezosLikeBlockchainExplorer

### DIFF
--- a/core/src/wallet/tezos/TezosLikeAccount.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount.cpp
@@ -129,7 +129,7 @@ namespace ledger {
                 if (transaction.type == api::TezosOperationTag::OPERATION_TAG_ORIGINATION && transaction.status == 1) {
                     updateOriginatedAccounts(sql, operation);
                 }
-                out.push_back(operation);               
+                out.push_back(operation);
                 result = static_cast<int>(transaction.type);
             }
 
@@ -137,7 +137,7 @@ namespace ledger {
                 operation.amount = transaction.value;
                 operation.type = api::OperationType::RECEIVE;
                 operation.refreshUid();
-                out.push_back(operation);   
+                out.push_back(operation);
                 result = static_cast<int>(transaction.type);
             }
         }
@@ -164,13 +164,13 @@ namespace ledger {
                 auto originatedAccountUid = TezosLikeAccountDatabaseHelper::createOriginatedAccountUid(getAccountUid(), origAccount.address);
 
             const auto found = std::find_if (
-                _originatedAccounts.begin(), 
-                _originatedAccounts.end(), 
-                [&originatedAccountUid](const std::shared_ptr<api::TezosLikeOriginatedAccount>& element) { 
+                _originatedAccounts.begin(),
+                _originatedAccounts.end(),
+                [&originatedAccountUid](const std::shared_ptr<api::TezosLikeOriginatedAccount>& element) {
                     return std::dynamic_pointer_cast<TezosLikeOriginatedAccount>(element)->getAccountUid() == originatedAccountUid;
                 });
 
-            if (found == _originatedAccounts.end()) {    
+            if (found == _originatedAccounts.end()) {
                 _originatedAccounts.emplace_back(
                         std::make_shared<TezosLikeOriginatedAccount>(originatedAccountUid,
                                                                      origAccount.address,
@@ -205,10 +205,9 @@ namespace ledger {
             if (cachedBalance.hasValue()) {
                 return FuturePtr<Amount>::successful(std::make_shared<Amount>(cachedBalance.getValue()));
             }
-            std::vector<TezosLikeKeychain::Address> listAddresses{_keychain->getAddress()};
             auto currency = getWallet()->getCurrency();
             auto self = getSelf();
-            return _explorer->getBalance(listAddresses).mapPtr<Amount>(getMainExecutionContext(), [self, currency](
+            return _explorer->getBalance(_keychain->getAddress()).mapPtr<Amount>(getMainExecutionContext(), [self, currency](
                     const std::shared_ptr<BigInt> &balance) -> std::shared_ptr<Amount> {
                 Amount b(currency, 0, BigInt(balance->toString()));
                 self->getWallet()->updateBalanceCache(self->getIndex(), b);

--- a/core/src/wallet/tezos/TezosLikeAccount2.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount2.cpp
@@ -215,7 +215,7 @@ namespace ledger {
                 // Check if balance is sufficient
                 auto currency = self->getWallet()->getCurrency();
                 auto accountAddress = TezosLikeAddress::fromBase58(senderAddress, currency);
-                return explorer->getBalance(std::vector<std::shared_ptr<TezosLikeAddress>>{accountAddress}).flatMapPtr<api::TezosLikeTransaction>(
+                return explorer->getBalance(accountAddress).flatMapPtr<api::TezosLikeTransaction>(
                         self->getMainExecutionContext(),
                         [self, request, explorer, accountAddress, currency, senderAddress](const std::shared_ptr<BigInt> &balance) {
                             // Check if all needed values are set

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -36,40 +36,33 @@
 
 namespace ledger {
     namespace core {
+
         ExternalTezosLikeBlockchainExplorer::ExternalTezosLikeBlockchainExplorer(
                 const std::shared_ptr<api::ExecutionContext> &context,
                 const std::shared_ptr<HttpClient> &http,
                 const api::TezosLikeNetworkParameters &parameters,
-                const std::shared_ptr<api::DynamicObject> &configuration) :
-                DedicatedContext(context),
-                TezosLikeBlockchainExplorer(configuration, {api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT}) {
-            _http = http;
-            _parameters = parameters;
+                const std::shared_ptr<ledger::core::api::DynamicObject> &configuration)
+            : TezosLikeBlockchainExplorer(
+                context, http, parameters, configuration,
+                {api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT})
+        {
             _bcd = configuration->getString(api::TezosConfiguration::BCD_API)
                 .value_or(api::TezosConfigurationDefaults::BCD_API_ENDPOINT);
         }
 
 
         Future<std::shared_ptr<BigInt>>
-        ExternalTezosLikeBlockchainExplorer::getBalance(const std::vector<TezosLikeKeychain::Address> &addresses) {
-            auto size = addresses.size();
-            if (size != 1) {
-                throw make_exception(api::ErrorCode::INVALID_ARGUMENT,
-                                     "Can only get balance of 1 address from Tezos Node, but got {} addresses",
-                                     addresses.size());
-            }
-            std::string addressesStr = addresses[0]->toString();
-            return getHelper(fmt::format("account/{}", addressesStr),
-                             "total_balance",
-                             std::unordered_map<std::string, std::string>{},
-                             "0",
-                             "",
-                             true
-            );
+        ExternalTezosLikeBlockchainExplorer::getBalance(const TezosLikeKeychain::Address &address) const {
+            return getHelper(fmt::format("account/{}", address->toString()),
+                            "total_balance",
+                            std::unordered_map<std::string, std::string>{},
+                            "0",
+                            "",
+                            true);
         }
 
         Future<std::shared_ptr<BigInt>>
-        ExternalTezosLikeBlockchainExplorer::getFees() {
+        ExternalTezosLikeBlockchainExplorer::getFees() const {
             // The best value is probably
             // divider_tx = (n_ops - n_ops_failed - n_ops_contract -
             //     n_seed_nonce_revelation - n_double_baking_evidence -
@@ -89,7 +82,7 @@ namespace ledger {
                         //Is there a fees field ?
                         if (!json.IsObject()) {
                             throw make_exception(api::ErrorCode::HTTP_ERROR,
-                                                 fmt::format("Failed to get fees from network, no (or malformed) response"));
+                                                  fmt::format("Failed to get fees from network, no (or malformed) response"));
                         }
 
                         // Return 0 if the block had no transaction at all
@@ -113,7 +106,7 @@ namespace ledger {
                         }
                         if (feesValueStr.empty()) {
                             throw make_exception(api::ErrorCode::HTTP_ERROR,
-                                                 "Failed to get fees from network, no (or malformed) response");
+                                                  "Failed to get fees from network, no (or malformed) response");
                         }
 
                         const auto totalFees = api::BigInt::fromDecimalString(feesValueStr, 6, ".");
@@ -129,7 +122,7 @@ namespace ledger {
         }
 
         Future<std::shared_ptr<BigInt>>
-        ExternalTezosLikeBlockchainExplorer::getGasPrice() {
+        ExternalTezosLikeBlockchainExplorer::getGasPrice() const {
             const bool parseNumbersAsString = true;
             const auto gasPriceField = "gas_price";
 
@@ -140,7 +133,7 @@ namespace ledger {
                         if (!json.IsObject() || !json.HasMember(gasPriceField) ||
                             !json[gasPriceField].IsString()) {
                             throw make_exception(api::ErrorCode::HTTP_ERROR,
-                                                 fmt::format("Failed to get gas_price from network, no (or malformed) field \"{}\" in response", gasPriceField));
+                                                  fmt::format("Failed to get gas_price from network, no (or malformed) field \"{}\" in response", gasPriceField));
                         }
                         const std::string apiGasPrice = json[gasPriceField].GetString();
                         const std::string picoTezGasPrice = api::BigInt::fromDecimalString(apiGasPrice, 6, ".")->toString(10);
@@ -154,89 +147,58 @@ namespace ledger {
             body << '"' << hex::toString(transaction) << '"';
             auto bodyString = body.str();
             return _http->POST("/injection/operation?chain=main",
-                               std::vector<uint8_t>(bodyString.begin(), bodyString.end()),
-                               std::unordered_map<std::string, std::string>{{"Content-Type", "application/json"}},
-                               getRPCNodeEndpoint())
-                    .json().template map<String>(getExplorerContext(),
-                                                 [](const HttpRequest::JsonResult &result) -> String {
-                                                     auto &json = *std::get<1>(result);
+                                std::vector<uint8_t>(bodyString.begin(), bodyString.end()),
+                                std::unordered_map<std::string, std::string>{{"Content-Type", "application/json"}},
+                                getRPCNodeEndpoint())
+                    .json().template map<String>(getContext(),
+                                                  [](const HttpRequest::JsonResult &result) -> String {
+                                                      auto &json = *std::get<1>(result);
 
-                                                     if (!json.IsString()) {
-                                                         throw make_exception(api::ErrorCode::HTTP_ERROR,
+                                                      if (!json.IsString()) {
+                                                          throw make_exception(api::ErrorCode::HTTP_ERROR,
                                                                               "Failed to parse broadcast transaction response, missing transaction hash");
-                                                     }
-                                                     return json.GetString();
-                                                 });
+                                                      }
+                                                      return json.GetString();
+                                                  });
         }
 
-        Future<void *> ExternalTezosLikeBlockchainExplorer::startSession() {
-            std::string sessionToken = fmt::format("{}", std::rand());
-            _sessions.insert(std::make_pair(sessionToken, 0));
-            return Future<void *>::successful(new std::string(sessionToken));
-        }
-
-        Future<Unit> ExternalTezosLikeBlockchainExplorer::killSession(void *session) {
-            if (session) {
-                _sessions.erase(*(reinterpret_cast<std::string *>(session)));
-            }
-            return Future<Unit>::successful(unit);
-        }
-
-        Future<Bytes> ExternalTezosLikeBlockchainExplorer::getRawTransaction(const String &transactionHash) {
-            // WARNING: not implemented
-            throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING,
-                                 "Endpoint to get raw transactions is not implemented.");
-        }
-
-        Future<String> ExternalTezosLikeBlockchainExplorer::pushTransaction(const std::vector<uint8_t> &transaction) {
+        Future<String>
+        ExternalTezosLikeBlockchainExplorer::pushTransaction(const std::vector<uint8_t> &transaction) {
             return pushLedgerApiTransaction(transaction);
         }
 
         FuturePtr<TezosLikeBlockchainExplorer::TransactionsBulk>
-        ExternalTezosLikeBlockchainExplorer::getTransactions(const std::vector<std::string> &addresses,
-                                                             Option<std::string> offset,
-                                                             Option<void *> session) {
-            auto tryOffset = Try<uint64_t>::from([=]() -> uint64_t {
-                return std::stoul(offset.getValueOr(""), nullptr, 10);
-            });
+        ExternalTezosLikeBlockchainExplorer::getTransactions(const std::string& address,
+                                                             const Either<std::string, uint32_t>& token) const {
 
-            uint64_t localOffset = tryOffset.isSuccess() ? tryOffset.getValue() : 0;
-            uint64_t limit = 100;
-            if (session.hasValue()) {
-                auto s = _sessions[*((std::string *)session.getValue())];
-                localOffset += limit * s;
-                _sessions[*reinterpret_cast<std::string *>(session.getValue())]++;
-            }
-            if (addresses.size() != 1) {
-                throw make_exception(api::ErrorCode::INVALID_ARGUMENT,
-                                     "Can only get transactions for 1 address from Tezos Node, but got {} addresses",
-                                     addresses.size());
-            }
-            std::string params = fmt::format("?limit={}",limit);
+            const uint64_t localOffset = token.isRight() ? token.getRight() : 0;
+            const uint64_t limit = 100;
+            std::string params = fmt::format("?limit={}", limit);
             if (localOffset > 0) {
-                params += fmt::format("&offset={}",localOffset);
+                params += fmt::format("&offset={}", localOffset);
             }
             using EitherTransactionsBulk = Either<Exception, std::shared_ptr<TransactionsBulk>>;
-            return _http->GET(fmt::format("account/{}/op{}", addresses[0], params))
+            return _http->GET(fmt::format("account/{}/op{}", address, params))
                     .template json<TransactionsBulk, Exception>(
                             LedgerApiParser<TransactionsBulk,
                             TezosLikeTransactionsBulkParser>())
-                    .template mapPtr<TransactionsBulk>(getExplorerContext(),
-                                                           [limit](const EitherTransactionsBulk &result) {
-                                                               if (result.isLeft()) {
-                                                                   // Because it fails when there are no ops
-                                                                   return std::make_shared<TransactionsBulk>();
-                                                               } else {
-                                                                   result.getRight()->hasNext = result.getRight()->transactions.size() == limit;
-                                                                   return result.getRight();
-                                                               }
-                                                           });
+                    .template mapPtr<TransactionsBulk>(getContext(),
+                                                            [limit](const EitherTransactionsBulk &result) {
+                                                                if (result.isLeft()) {
+                                                                    // Because it fails when there are no ops
+                                                                    return std::make_shared<TransactionsBulk>();
+                                                                } else {
+                                                                    result.getRight()->hasNext = result.getRight()->transactions.size() == limit;
+                                                                    return result.getRight();
+                                                                }
+                                                            });
         }
 
-        FuturePtr<Block> ExternalTezosLikeBlockchainExplorer::getCurrentBlock() const {
+        FuturePtr<Block>
+        ExternalTezosLikeBlockchainExplorer::getCurrentBlock() const {
             return _http->GET("block/head")
                     .template json<Block, Exception>(LedgerApiParser<Block, TezosLikeBlockParser>())
-                    .template mapPtr<Block>(getExplorerContext(),
+                    .template mapPtr<Block>(getContext(),
                                             [](const Either<Exception, std::shared_ptr<Block>> &result) {
                                                 if (result.isLeft()) {
                                                     throw result.getLeft();
@@ -251,20 +213,145 @@ namespace ledger {
             return getLedgerApiTransactionByHash(transactionHash);
         }
 
-        Future<int64_t> ExternalTezosLikeBlockchainExplorer::getTimestamp() const {
-            return getLedgerApiTimestamp();
-        }
-
-        std::shared_ptr<api::ExecutionContext> ExternalTezosLikeBlockchainExplorer::getExplorerContext() const {
-            return _executionContext;
-        }
-
-        api::TezosLikeNetworkParameters ExternalTezosLikeBlockchainExplorer::getNetworkParameters() const {
-            return _parameters;
-        }
-
         std::string ExternalTezosLikeBlockchainExplorer::getExplorerVersion() const {
             return "";
+        }
+
+        Future<std::shared_ptr<BigInt>>
+        ExternalTezosLikeBlockchainExplorer::getEstimatedGasLimit(const std::string &address) const {
+            return FuturePtr<BigInt>::successful(
+                    std::make_shared<BigInt>(api::TezosConfigurationDefaults::TEZOS_DEFAULT_GAS_LIMIT)
+            );
+        }
+
+        Future<std::shared_ptr<GasLimit>>
+        ExternalTezosLikeBlockchainExplorer::getEstimatedGasLimit(const std::shared_ptr<TezosLikeTransactionApi> &tx) const {
+            return TezosLikeBlockchainExplorer::getEstimatedGasLimit(_http, getContext(), tx);
+        }
+
+        Future<std::shared_ptr<BigInt>>
+        ExternalTezosLikeBlockchainExplorer::getStorage(const std::string &address) const {
+            return FuturePtr<BigInt>::successful(
+                    std::make_shared<BigInt>(api::TezosConfigurationDefaults::TEZOS_DEFAULT_STORAGE_LIMIT)
+            );
+        }
+
+        Future<std::shared_ptr<BigInt>>
+        ExternalTezosLikeBlockchainExplorer::getCounter(const std::string &address) const {
+            return getHelper(fmt::format("/chains/main/blocks/head/context/contracts/{}/counter", address),
+                              "",
+                              std::unordered_map<std::string, std::string>{},
+                              "0",
+                              getRPCNodeEndpoint()
+            );
+        }
+
+        Future<std::vector<uint8_t>>
+        ExternalTezosLikeBlockchainExplorer::forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx) const {
+            return TezosLikeBlockchainExplorer::forgeKTOperation(tx,
+                                                                  getExplorerContext(),
+                                                                  _http,
+                                                                  getRPCNodeEndpoint());
+        }
+
+        Future<std::string>
+        ExternalTezosLikeBlockchainExplorer::getManagerKey(const std::string &address) const {
+            return TezosLikeBlockchainExplorer::getManagerKey(address,
+                                                              getExplorerContext(),
+                                                              _http,
+                                                              getRPCNodeEndpoint());
+        }
+
+        Future<bool>
+        ExternalTezosLikeBlockchainExplorer::isAllocated(const std::string &address) const {
+            return TezosLikeBlockchainExplorer::isAllocated(address,
+                                                            getExplorerContext(),
+                                                            _http,
+                                                            getRPCNodeEndpoint());
+        }
+
+        Future<std::string>
+        ExternalTezosLikeBlockchainExplorer::getCurrentDelegate(const std::string &address) const {
+            return TezosLikeBlockchainExplorer::getCurrentDelegate(address,
+                                                                    getExplorerContext(),
+                                                                    _http,
+                                                                    getRPCNodeEndpoint());
+        }
+
+        Future<bool>
+        ExternalTezosLikeBlockchainExplorer::isFunded(const std::string &address) const {
+            return _http->GET(fmt::format("account/{}", address))
+                .json(false, true).map<bool>(getExplorerContext(), [=](const HttpRequest::JsonResult &result) {
+                    auto& connection = *std::get<0>(result);
+                    if (connection.getStatusCode() == 404) {
+                        //an empty account
+                        return false;
+                    }
+                    else if (connection.getStatusCode() < 200 || connection.getStatusCode() >= 300) {
+                        throw Exception(api::ErrorCode::HTTP_ERROR, connection.getStatusText());
+                    }
+                    else {
+                        auto& json = *std::get<1>(result);
+
+                        // look for the is_funded field
+                        const auto field = "is_funded";
+                        if (!json.IsObject() || !json.HasMember(field) ||
+                            !json[field].IsBool()) {
+                            throw make_exception(api::ErrorCode::HTTP_ERROR,
+                                                "Failed to get is_funded from network, no (or malformed) field \"result\" in response");
+                        }
+
+                        return json[field].GetBool();
+                    }
+                });
+        }
+
+        Future<std::shared_ptr<BigInt>>
+        ExternalTezosLikeBlockchainExplorer::getTokenBalance(const std::string& accountAddress,
+                                                             const std::string& tokenAddress) const {
+            const auto parseNumbersAsString = true;
+            return _http->GET(fmt::format("/account/mainnet/{}", accountAddress), {}, _bcd)
+                .json(parseNumbersAsString)
+                .mapPtr<BigInt>(getContext(),
+                    [=](const HttpRequest::JsonResult &result) {
+                        const auto &json = *std::get<1>(result);
+                        if (!json.HasMember("tokens") || !json["tokens"].IsArray()) {
+                            throw make_exception(api::ErrorCode::HTTP_ERROR,
+                                fmt::format("Failed to get tokens for {}, no (or malformed) field `tokens` in response", accountAddress));
+                        }
+
+                        const auto tokens = json["tokens"].GetArray();
+                        for (const auto& token : tokens) {
+                            if (!token.HasMember("contract") || !token["contract"].IsString()) {
+                                throw make_exception(api::ErrorCode::HTTP_ERROR,
+                                    "Failed to get contract from network, no (or malformed) field `contract` in response");
+                            }
+                            if (token["contract"].GetString() == tokenAddress) {
+                                if (!token.HasMember("balance") || !token["balance"].IsString()) {
+                                    throw make_exception(api::ErrorCode::HTTP_ERROR,
+                                        "Failed to get contract balance from network, no (or malformed) field `balance` in response");
+                                }
+                                return std::make_shared<BigInt>(BigInt::fromString(token["balance"].GetString()));
+                            }
+                        }
+                        return std::make_shared<BigInt>(BigInt::ZERO);
+                    });
+        }
+
+        Future<bool>
+        ExternalTezosLikeBlockchainExplorer::isDelegate(const std::string &address) const {
+            return _http->GET(fmt::format("account/{}", address))
+                .json(false).map<bool>(getExplorerContext(), [=](const HttpRequest::JsonResult &result) {
+                    auto& json = *std::get<1>(result);
+                    // look for the is_active_delegate field
+                    const auto field = "is_active_delegate";
+                    if (!json.IsObject() || !json.HasMember(field) ||
+                        !json[field].IsBool()) {
+                        throw make_exception(api::ErrorCode::HTTP_ERROR,
+                                            "Failed to get is_active_delegate from network, no (or malformed) field in response");
+                    }
+                    return json[field].GetBool();
+                });
         }
 
         Future<std::shared_ptr<BigInt>>
@@ -273,7 +360,7 @@ namespace ledger {
                                                        const std::unordered_map<std::string, std::string> &params,
                                                        const std::string &fallbackValue,
                                                        const std::string &forceUrl,
-                                                       bool isDecimal) {
+                                                       bool isDecimal) const {
             const bool parseNumbersAsString = true;
             const bool ignoreStatusCode = true;
             auto networkId = getNetworkParameters().Identifier;
@@ -305,8 +392,8 @@ namespace ledger {
                                             !json.HasMember(field.c_str()) ||
                                             !json[field.c_str()].IsString()) && !json.IsString()) {
                                             throw make_exception(api::ErrorCode::HTTP_ERROR,
-                                                                 fmt::format("Failed to get {} for {}", field,
-                                                                             networkId));
+                                                                  fmt::format("Failed to get {} for {}", field,
+                                                                              networkId));
                                         }
                                         std::string value = json.IsString() ? json.GetString() : json[field.c_str()].GetString();
                                         if (value == "0" && !fallbackValue.empty()) {
@@ -318,136 +405,5 @@ namespace ledger {
                                     });
         }
 
-        Future<std::shared_ptr<BigInt>>
-        ExternalTezosLikeBlockchainExplorer::getEstimatedGasLimit(const std::string &address) {
-            return FuturePtr<BigInt>::successful(
-                    std::make_shared<BigInt>(api::TezosConfigurationDefaults::TEZOS_DEFAULT_GAS_LIMIT)
-            );
-        }
-
-        Future<std::shared_ptr<GasLimit>>
-        ExternalTezosLikeBlockchainExplorer::getEstimatedGasLimit(const std::shared_ptr<TezosLikeTransactionApi> &tx) {
-            return TezosLikeBlockchainExplorer::getEstimatedGasLimit(_http, getContext(), tx);
-        }
-
-        Future<std::shared_ptr<BigInt>>
-        ExternalTezosLikeBlockchainExplorer::getStorage(const std::string &address) {
-            return FuturePtr<BigInt>::successful(
-                    std::make_shared<BigInt>(api::TezosConfigurationDefaults::TEZOS_DEFAULT_STORAGE_LIMIT)
-            );
-        }
-
-        Future<std::shared_ptr<BigInt>>
-        ExternalTezosLikeBlockchainExplorer::getCounter(const std::string &address) {
-            return getHelper(fmt::format("/chains/main/blocks/head/context/contracts/{}/counter", address),
-                             "",
-                             std::unordered_map<std::string, std::string>{},
-                             "0",
-                             getRPCNodeEndpoint()
-            );
-        }
-
-        Future<std::vector<uint8_t>> ExternalTezosLikeBlockchainExplorer::forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx) {
-            return TezosLikeBlockchainExplorer::forgeKTOperation(tx,
-                                                                 getExplorerContext(),
-                                                                 _http,
-                                                                 getRPCNodeEndpoint());
-        }
-
-        Future<std::string> ExternalTezosLikeBlockchainExplorer::getManagerKey(const std::string &address) {
-            return TezosLikeBlockchainExplorer::getManagerKey(address,
-                                                              getExplorerContext(),
-                                                              _http,
-                                                              getRPCNodeEndpoint());
-        }
-
-        Future<bool> ExternalTezosLikeBlockchainExplorer::isAllocated(const std::string &address) {
-            return TezosLikeBlockchainExplorer::isAllocated(address,
-                                                            getExplorerContext(),
-                                                            _http,
-                                                            getRPCNodeEndpoint());
-        }
-
-        Future<std::string> ExternalTezosLikeBlockchainExplorer::getCurrentDelegate(const std::string &address) {
-            return TezosLikeBlockchainExplorer::getCurrentDelegate(address,
-                                                                   getExplorerContext(),
-                                                                   _http,
-                                                                   getRPCNodeEndpoint());
-        }
-
-        Future<std::shared_ptr<BigInt>>
-        ExternalTezosLikeBlockchainExplorer::getTokenBalance(const std::string& accountAddress,
-                                                             const std::string& tokenAddress) const {
-            const auto parseNumbersAsString = true;
-            return _http->GET(fmt::format("/account/mainnet/{}", accountAddress), {}, _bcd)
-                .json(parseNumbersAsString)
-                .mapPtr<BigInt>(getContext(),
-                    [=](const HttpRequest::JsonResult &result) {
-                       const auto &json = *std::get<1>(result);
-                       if (!json.HasMember("tokens") || !json["tokens"].IsArray()) {
-                           throw make_exception(api::ErrorCode::HTTP_ERROR,
-                               fmt::format("Failed to get tokens for {}, no (or malformed) field `tokens` in response", accountAddress));
-                       }
-
-                       const auto tokens = json["tokens"].GetArray();
-                       for (const auto& token : tokens) {
-                           if (!token.HasMember("contract") || !token["contract"].IsString()) {
-                               throw make_exception(api::ErrorCode::HTTP_ERROR,
-                                   "Failed to get contract from network, no (or malformed) field `contract` in response");
-                           }
-                           if (token["contract"].GetString() == tokenAddress) {
-                               if (!token.HasMember("balance") || !token["balance"].IsString()) {
-                                   throw make_exception(api::ErrorCode::HTTP_ERROR,
-                                       "Failed to get contract balance from network, no (or malformed) field `balance` in response");
-                               }
-                               return std::make_shared<BigInt>(BigInt::fromString(token["balance"].GetString()));
-                           }
-                       }
-                       return std::make_shared<BigInt>(BigInt::ZERO);
-                    });
-        }
-
-        Future<bool> ExternalTezosLikeBlockchainExplorer::isFunded(const std::string &address) {
-            return
-                _http->GET(fmt::format("account/{}", address))
-                    .json(false, true).map<bool>(getExplorerContext(), [=](const HttpRequest::JsonResult &result) {
-                        auto& connection = *std::get<0>(result);
-                        if (connection.getStatusCode() == 404) {
-                            //an empty account
-                            return false;
-                        }
-                        else if (connection.getStatusCode() < 200 || connection.getStatusCode() >= 300) {
-                            throw Exception(api::ErrorCode::HTTP_ERROR, connection.getStatusText());
-                        }
-                        else {
-                            auto& json = *std::get<1>(result);
-
-                            // look for the is_funded field
-                            const auto field = "is_funded";
-                            if (!json.IsObject() || !json.HasMember(field) ||
-                                !json[field].IsBool()) {
-                                throw make_exception(api::ErrorCode::HTTP_ERROR,
-                                                    "Failed to get is_funded from network, no (or malformed) field \"result\" in response");
-                            }
-
-                            return json[field].GetBool();
-                        }
-                    });
-        }
-
-        Future<bool> ExternalTezosLikeBlockchainExplorer::isDelegate(const std::string &address) {
-                return _http->GET(fmt::format("account/{}", address))
-                    .json(false).map<bool>(getExplorerContext(), [=](const HttpRequest::JsonResult &result) {
-                        auto& json = *std::get<1>(result);
-                        // look for the is_active_delegate field
-                        const auto field = "is_active_delegate";
-                        if (!json.IsObject() || !json.HasMember(field) ||
-                            !json[field].IsBool()) {
-                            throw make_exception(api::ErrorCode::HTTP_ERROR,
-                                                "Failed to get is_active_delegate from network, no (or malformed) field in response");
-                        }
-                        return json[field].GetBool();
-                    });
-        }
-    }
-}
+    } // namespace core
+} // namespace ledger

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
@@ -28,8 +28,9 @@
  *
  */
 
-#pragma once
-#include <wallet/common/explorers/AbstractLedgerApiBlockchainExplorer.h>
+#ifndef LEDGER_CORE_EXTERNALTEZOSLIKEBLOCKCHAINEXPLORER_H
+#define LEDGER_CORE_EXTERNALTEZOSLIKEBLOCKCHAINEXPLORER_H
+
 #include <wallet/tezos/explorers/TezosLikeBlockchainExplorer.h>
 #include <wallet/tezos/explorers/api/TezosLikeTransactionsParser.h>
 #include <wallet/tezos/explorers/api/TezosLikeTransactionsBulkParser.h>
@@ -39,86 +40,76 @@
 
 namespace ledger {
     namespace core {
-        using ExternalApiBlockchainExplorer = AbstractLedgerApiBlockchainExplorer<
-                TezosLikeBlockchainExplorerTransaction,
-                TezosLikeBlockchainExplorer::TransactionsBulk,
-                TezosLikeTransactionsParser,
-                TezosLikeTransactionsBulkParser,
-                TezosLikeBlockParser,
-                api::TezosLikeNetworkParameters>;
 
-        class ExternalTezosLikeBlockchainExplorer : public TezosLikeBlockchainExplorer,
-                                                    public ExternalApiBlockchainExplorer,
-                                                    public DedicatedContext,
-                                                    public std::enable_shared_from_this<ExternalTezosLikeBlockchainExplorer> {
+        class ExternalTezosLikeBlockchainExplorer : public TezosLikeBlockchainExplorer
+        {
         public:
-            ExternalTezosLikeBlockchainExplorer(const std::shared_ptr<api::ExecutionContext> &context,
-                                                const std::shared_ptr<HttpClient> &http,
-                                                const api::TezosLikeNetworkParameters &parameters,
-                                                const std::shared_ptr<api::DynamicObject> &configuration);
+            ExternalTezosLikeBlockchainExplorer(
+                const std::shared_ptr<api::ExecutionContext> &context,
+                const std::shared_ptr<HttpClient> &http,
+                const api::TezosLikeNetworkParameters &parameters,
+                const std::shared_ptr<ledger::core::api::DynamicObject> &configuration);
 
             Future<std::shared_ptr<BigInt>>
-            getBalance(const std::vector<TezosLikeKeychain::Address> &addresses) override;
+            getBalance(const TezosLikeKeychain::Address &address) const override;
 
             Future<std::shared_ptr<BigInt>>
-            getFees() override;
+            getFees() const override;
 
             Future<std::shared_ptr<BigInt>>
-            getGasPrice() override;
+            getGasPrice() const override;
 
-            Future<String> pushLedgerApiTransaction(const std::vector<uint8_t> &transaction) override;
+            Future<String> pushLedgerApiTransaction(const std::vector<uint8_t> &transaction) override ;
 
-            Future<void *> startSession() override;
-
-            Future<Unit> killSession(void *session) override;
-
-            Future<Bytes> getRawTransaction(const String &transactionHash) override;
-
-            Future<String> pushTransaction(const std::vector<uint8_t> &transaction) override;
+            Future<String> pushTransaction(const std::vector<uint8_t>& transaction) override;
 
             FuturePtr<TezosLikeBlockchainExplorer::TransactionsBulk>
-            getTransactions(const std::vector<std::string> &addresses,
-                            Option<std::string> offset = Option<std::string>(),
-                            Option<void *> session = Option<void *>()) override;
+            getTransactions(const std::string& address,
+                            const Either<std::string, uint32_t>& token = {}) const override;
 
-            FuturePtr<Block> getCurrentBlock() const override;
+            FuturePtr<Block>
+            getCurrentBlock() const override;
 
-            FuturePtr<TezosLikeBlockchainExplorerTransaction>
+            FuturePtr<Transaction>
             getTransactionByHash(const String &transactionHash) const override;
-
-            Future<int64_t> getTimestamp() const override;
-
-            std::shared_ptr<api::ExecutionContext> getExplorerContext() const override;
-
-            api::TezosLikeNetworkParameters getNetworkParameters() const override;
 
             std::string getExplorerVersion() const override;
 
             Future<std::shared_ptr<BigInt>>
-            getEstimatedGasLimit(const std::string &address) override;
+            getEstimatedGasLimit(const std::string &address) const override;
 
             Future<std::shared_ptr<GasLimit>>
-            getEstimatedGasLimit(const std::shared_ptr<TezosLikeTransactionApi> &transaction) override;
+            getEstimatedGasLimit(const std::shared_ptr<TezosLikeTransactionApi> &tx) const override;
 
             Future<std::shared_ptr<BigInt>>
-            getStorage(const std::string &address) override;
-
-            Future<std::shared_ptr<BigInt>> getCounter(const std::string &address) override;
-
-            Future<std::vector<uint8_t>> forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx) override;
-
-            Future<std::string> getManagerKey(const std::string &address) override;
-
-            Future<bool> isAllocated(const std::string &address) override;
-
-            Future<std::string> getCurrentDelegate(const std::string &address) override;
-
-            Future<bool> isFunded(const std::string &address) override;
+            getStorage(const std::string &address) const override;
 
             Future<std::shared_ptr<BigInt>>
-            getTokenBalance(const std::string& accountAddress, const std::string& tokenAddress) const override;
+            getCounter(const std::string &address) const override;
 
-            Future<bool> isDelegate(const std::string &address) override;
+            Future<std::vector<uint8_t>>
+            forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx) const override;
+
+            Future<std::string>
+            getManagerKey(const std::string &address) const override;
+
+            Future<bool>
+            isAllocated(const std::string &address) const override;
+
+            Future<std::string>
+            getCurrentDelegate(const std::string &address) const override;
+
+            /// Check that the account is funded.
+            Future<bool>
+            isFunded(const std::string &address) const override;
+
+            /// Get a token balance for an account
+            Future<std::shared_ptr<BigInt>>
+            getTokenBalance(const std::string& accountAddress,
+                            const std::string& tokenAddress) const override;
+
+            Future<bool>
+            isDelegate(const std::string &address) const override;
 
         private:
             /*
@@ -132,14 +123,16 @@ namespace ledger {
             Future<std::shared_ptr<BigInt>>
             getHelper(const std::string &url,
                       const std::string &field,
-                      const std::unordered_map<std::string, std::string> &params = std::unordered_map<std::string, std::string>(),
+                      const std::unordered_map<std::string, std::string> &params = {},
                       const std::string &fallbackValue = "",
                       const std::string &forceUrl = "",
-                      bool isDecimal = false);
+                      bool isDecimal = false) const;
 
-            api::TezosLikeNetworkParameters _parameters;
-            std::unordered_map<std::string, uint64_t> _sessions;
+        private:
             std::string _bcd;
         };
-    }
-}
+
+    } // namespace core
+} // namespace ledger
+
+#endif //LEDGER_CORE_EXTERNALTEZOSLIKEBLOCKCHAINEXPLORER_H

--- a/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.h
@@ -28,11 +28,9 @@
  *
  */
 
-
 #ifndef LEDGER_CORE_NODETEZOSLIKEBLOCKCHAINEXPLORER_H
 #define LEDGER_CORE_NODETEZOSLIKEBLOCKCHAINEXPLORER_H
 
-#include <wallet/common/explorers/AbstractLedgerApiBlockchainExplorer.h>
 #include <wallet/tezos/explorers/TezosLikeBlockchainExplorer.h>
 #include <wallet/tezos/explorers/api/TezosLikeTransactionsParser.h>
 #include <wallet/tezos/explorers/api/TezosLikeTransactionsBulkParser.h>
@@ -42,80 +40,76 @@
 
 namespace ledger {
     namespace core {
-        using LedgerApiBlockchainExplorer = AbstractLedgerApiBlockchainExplorer<TezosLikeBlockchainExplorerTransaction, TezosLikeBlockchainExplorer::TransactionsBulk, TezosLikeTransactionsParser, TezosLikeTransactionsBulkParser, TezosLikeBlockParser, api::TezosLikeNetworkParameters>;
 
-        class NodeTezosLikeBlockchainExplorer : public TezosLikeBlockchainExplorer,
-                                                public LedgerApiBlockchainExplorer,
-                                                public DedicatedContext,
-                                                public std::enable_shared_from_this<NodeTezosLikeBlockchainExplorer> {
+        class NodeTezosLikeBlockchainExplorer : public TezosLikeBlockchainExplorer
+        {
         public:
-            NodeTezosLikeBlockchainExplorer(const std::shared_ptr<api::ExecutionContext> &context,
-                                            const std::shared_ptr<HttpClient> &http,
-                                            const api::TezosLikeNetworkParameters &parameters,
-                                            const std::shared_ptr<api::DynamicObject> &configuration);
+            NodeTezosLikeBlockchainExplorer(
+                const std::shared_ptr<api::ExecutionContext> &context,
+                const std::shared_ptr<HttpClient> &http,
+                const api::TezosLikeNetworkParameters &parameters,
+                const std::shared_ptr<ledger::core::api::DynamicObject> &configuration);
 
             Future<std::shared_ptr<BigInt>>
-            getBalance(const std::vector<TezosLikeKeychain::Address> &addresses) override;
+            getBalance(const TezosLikeKeychain::Address &address) const override;
 
             Future<std::shared_ptr<BigInt>>
-            getFees() override;
+            getFees() const override;
 
             Future<std::shared_ptr<BigInt>>
-            getGasPrice() override;
+            getGasPrice() const override;
 
-            Future<String> pushLedgerApiTransaction(const std::vector<uint8_t> &transaction) override;
+            Future<String>
+            pushLedgerApiTransaction(const std::vector<uint8_t> &transaction) override;
 
-            Future<void *> startSession() override;
+            Future<String>
+            pushTransaction(const std::vector<uint8_t>& transaction) override;
 
-            Future<Unit> killSession(void *session) override;
+            FuturePtr<TransactionsBulk>
+            getTransactions(const std::string& address,
+                            const Either<std::string, uint32_t>& token = {}) const override;
 
-            Future<Bytes> getRawTransaction(const String &transactionHash) override;
+            FuturePtr<Block>
+            getCurrentBlock() const override;
 
-            Future<String> pushTransaction(const std::vector<uint8_t> &transaction) override;
-
-            FuturePtr<TezosLikeBlockchainExplorer::TransactionsBulk>
-            getTransactions(const std::vector<std::string> &addresses,
-                            Option<std::string> fromBlockHash = Option<std::string>(),
-                            Option<void *> session = Option<void *>()) override;
-
-            FuturePtr<Block> getCurrentBlock() const override;
-
-            FuturePtr<TezosLikeBlockchainExplorerTransaction>
+            FuturePtr<Transaction>
             getTransactionByHash(const String &transactionHash) const override;
-
-            Future<int64_t> getTimestamp() const override;
-
-            std::shared_ptr<api::ExecutionContext> getExplorerContext() const override;
-
-            api::TezosLikeNetworkParameters getNetworkParameters() const override;
 
             std::string getExplorerVersion() const override;
 
             Future<std::shared_ptr<BigInt>>
-            getEstimatedGasLimit(const std::string &address) override;
+            getEstimatedGasLimit(const std::string &address) const override;
 
-            virtual Future<std::shared_ptr<GasLimit>>
-            getEstimatedGasLimit(const std::shared_ptr<TezosLikeTransactionApi> &transaction) override;
-
-            Future<std::shared_ptr<BigInt>>
-            getStorage(const std::string &address) override;
-
-            Future<std::shared_ptr<BigInt>> getCounter(const std::string &address) override;
-
-            Future<std::vector<uint8_t>> forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx) override ;
-
-            Future<std::string> getManagerKey(const std::string &address) override;
-
-            Future<bool> isAllocated(const std::string &address) override;
-
-            Future<std::string> getCurrentDelegate(const std::string &address) override;
-
-            Future<bool> isFunded(const std::string &address) override;
+            Future<std::shared_ptr<GasLimit>>
+            getEstimatedGasLimit(const std::shared_ptr<TezosLikeTransactionApi> &tx) const override;
 
             Future<std::shared_ptr<BigInt>>
-            getTokenBalance(const std::string& accountAddress, const std::string& tokenAddress) const override;
+            getStorage(const std::string &address) const override;
 
-            Future<bool> isDelegate(const std::string &address) override;
+            Future<std::shared_ptr<BigInt>>
+            getCounter(const std::string &address) const override;
+
+            Future<std::vector<uint8_t>>
+            forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx) const override;
+
+            Future<std::string>
+            getManagerKey(const std::string &address) const override;
+
+            Future<bool>
+            isAllocated(const std::string &address) const override;
+
+            Future<std::string>
+            getCurrentDelegate(const std::string &address) const override;
+
+            Future<bool>
+            isFunded(const std::string &address) const override;
+
+            Future<bool>
+            isDelegate(const std::string &address) const override;
+
+            Future<std::shared_ptr<BigInt>>
+            getTokenBalance(const std::string& accountAddress,
+                            const std::string& tokenAddress) const override;
 
         private:
             /*
@@ -129,12 +123,14 @@ namespace ledger {
             Future<std::shared_ptr<BigInt>>
             getHelper(const std::string &url,
                       const std::string &field,
-                      const std::unordered_map<std::string, std::string> &params = std::unordered_map<std::string, std::string>(),
-                      const std::string &fallbackValue = "");
+                      const std::unordered_map<std::string, std::string> &params = {},
+                      const std::string &fallbackValue = "") const;
 
-            api::TezosLikeNetworkParameters _parameters;
+        private:
             std::string _explorerVersion;
         };
-    }
-}
+
+    } // namespace core
+} // namespace ledger
+
 #endif //LEDGER_CORE_NODETEZOSLIKEBLOCKCHAINEXPLORER_H

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.cpp
@@ -28,7 +28,6 @@
  *
  */
 
-
 #include "TezosLikeBlockchainExplorer.h"
 #include <wallet/tezos/api_impl/TezosLikeTransactionApi.h>
 #include <api/TezosConfiguration.hpp>
@@ -43,32 +42,42 @@ namespace ledger {
     namespace core {
 
         TezosLikeBlockchainExplorer::TezosLikeBlockchainExplorer(
+                const std::shared_ptr<api::ExecutionContext> &context,
+                const std::shared_ptr<HttpClient> &http,
+                const api::TezosLikeNetworkParameters &parameters,
                 const std::shared_ptr<ledger::core::api::DynamicObject> &configuration,
-                const std::vector<std::string> &matchableKeys) : ConfigurationMatchable(matchableKeys) {
+                const std::vector<std::string> &matchableKeys)
+            : TezosLikeLedgerApiBlockchainExplorer()
+            , ConfigurationMatchable(matchableKeys)
+            , DedicatedContext(context)
+            , _parameters(parameters)
+        {
+            _http = http;
             setConfiguration(configuration);
             _rpcNode = configuration->getString(api::TezosConfiguration::TEZOS_NODE)
-                    .value_or(api::TezosConfigurationDefaults::TEZOS_DEFAULT_NODE);
+                .value_or(api::TezosConfigurationDefaults::TEZOS_DEFAULT_NODE);
         }
 
-        Future<std::vector<uint8_t>> TezosLikeBlockchainExplorer::forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx,
-                                                                                   const std::shared_ptr<api::ExecutionContext> &context,
-                                                                                   const std::shared_ptr<HttpClient> &http,
-                                                                                   const std::string &rpcNode) {
+        Future<std::vector<uint8_t>>
+        TezosLikeBlockchainExplorer::forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx,
+                                                      const std::shared_ptr<api::ExecutionContext> &context,
+                                                      const std::shared_ptr<HttpClient> &http,
+                                                      const std::string &rpcNode) {
             std::string params;
             switch (tx->getType()) {
                 case api::TezosOperationTag::OPERATION_TAG_TRANSACTION:
                     params = fmt::format("\"parameters\":"
-                                                 "{{\"entrypoint\":\"do\",\"value\":["
-                                                 "{{\"prim\":\"DROP\"}},"
-                                                 "{{\"prim\":\"NIL\",\"args\":[{{\"prim\":\"operation\"}}]}},"
-                                                 "{{\"prim\":\"PUSH\",\"args\":[{{\"prim\":\"key_hash\"}},{{\"string\":\"{}\"}}]}},"
-                                                 "{{\"prim\":\"IMPLICIT_ACCOUNT\"}},"
-                                                 "{{\"prim\":\"PUSH\",\"args\":[{{\"prim\":\"mutez\"}},{{\"int\":\"{}\"}}]}},"
-                                                 "{{\"prim\":\"UNIT\"}},"
-                                                 "{{\"prim\":\"TRANSFER_TOKENS\"}},"
-                                                 "{{\"prim\":\"CONS\"}}]}}",
-                                         tx->getReceiver()->toBase58(),
-                                         tx->getValue()->toString());
+                                                  "{{\"entrypoint\":\"do\",\"value\":["
+                                                  "{{\"prim\":\"DROP\"}},"
+                                                  "{{\"prim\":\"NIL\",\"args\":[{{\"prim\":\"operation\"}}]}},"
+                                                  "{{\"prim\":\"PUSH\",\"args\":[{{\"prim\":\"key_hash\"}},{{\"string\":\"{}\"}}]}},"
+                                                  "{{\"prim\":\"IMPLICIT_ACCOUNT\"}},"
+                                                  "{{\"prim\":\"PUSH\",\"args\":[{{\"prim\":\"mutez\"}},{{\"int\":\"{}\"}}]}},"
+                                                  "{{\"prim\":\"UNIT\"}},"
+                                                  "{{\"prim\":\"TRANSFER_TOKENS\"}},"
+                                                  "{{\"prim\":\"CONS\"}}]}}",
+                                          tx->getReceiver()->toBase58(),
+                                          tx->getValue()->toString());
                     break;
                 case api::TezosOperationTag::OPERATION_TAG_DELEGATION:
                     params = "\"parameters\":"
@@ -118,15 +127,16 @@ namespace ledger {
                     });
         }
 
-        Future<std::string> TezosLikeBlockchainExplorer::getManagerKey(const std::string &address,
-                                                                       const std::shared_ptr<api::ExecutionContext> &context,
-                                                                       const std::shared_ptr<HttpClient> &http,
-                                                                       const std::string &rpcNode) {
+        Future<std::string>
+        TezosLikeBlockchainExplorer::getManagerKey(const std::string &address,
+                                                   const std::shared_ptr<api::ExecutionContext> &context,
+                                                   const std::shared_ptr<HttpClient> &http,
+                                                   const std::string &rpcNode) {
             const bool parseNumbersAsString = true;
             std::unordered_map<std::string, std::string> headers{{"Content-Type", "application/json"}};
             return http->GET(fmt::format("/chains/main/blocks/head/context/contracts/{}/manager_key", address),
-                             std::unordered_map<std::string, std::string>{},
-                             rpcNode)
+                              std::unordered_map<std::string, std::string>{},
+                              rpcNode)
                     .json(parseNumbersAsString)
                     .map<std::string>(context, [](const HttpRequest::JsonResult &result) {
                         auto &json = *std::get<1>(result);
@@ -143,33 +153,35 @@ namespace ledger {
                     });
         }
 
-        Future<bool> TezosLikeBlockchainExplorer::isAllocated(const std::string &address,
-                                                              const std::shared_ptr<api::ExecutionContext> &context,
-                                                              const std::shared_ptr<HttpClient> &http,
-                                                              const std::string &rpcNode) {
+        Future<bool>
+        TezosLikeBlockchainExplorer::isAllocated(const std::string &address,
+                                                 const std::shared_ptr<api::ExecutionContext> &context,
+                                                 const std::shared_ptr<HttpClient> &http,
+                                                 const std::string &rpcNode) {
             const bool parseNumbersAsString = true;
             std::unordered_map<std::string, std::string> headers{{"Content-Type", "application/json"}};
             return http->GET(fmt::format("/chains/main/blocks/head/context/contracts/{}", address),
-                             std::unordered_map<std::string, std::string>{},
-                             rpcNode)
+                              std::unordered_map<std::string, std::string>{},
+                              rpcNode)
                     .json(parseNumbersAsString)
                     .map<bool>(context, [](const HttpRequest::JsonResult &result) {
-                       return true;
-                    }).recover(context, [] (const Exception &exception) {
+                        return true;
+                    }).recover(context, [](const Exception &exception) {
                         return false;
                     });
         }
 
-        Future<std::string> TezosLikeBlockchainExplorer::getCurrentDelegate(const std::string &address,
-                                                                           const std::shared_ptr<api::ExecutionContext> &context,
-                                                                           const std::shared_ptr<HttpClient> &http,
-                                                                           const std::string &rpcNode) {
+        Future<std::string>
+        TezosLikeBlockchainExplorer::getCurrentDelegate(const std::string &address,
+                                                        const std::shared_ptr<api::ExecutionContext> &context,
+                                                        const std::shared_ptr<HttpClient> &http,
+                                                        const std::string &rpcNode) {
             const bool parseNumbersAsString = true;
 
             std::unordered_map<std::string, std::string> headers{{"Content-Type", "application/json"}};
             return http->GET(fmt::format("/chains/main/blocks/head/context/contracts/{}/delegate", address),
-                             std::unordered_map<std::string, std::string>{},
-                             rpcNode)
+                              std::unordered_map<std::string, std::string>{},
+                              rpcNode)
                     .json(parseNumbersAsString)
                     .map<std::string>(context, [](const HttpRequest::JsonResult &result) {
                         auto &json = *std::get<1>(result);
@@ -177,19 +189,21 @@ namespace ledger {
                             return "";
                         }
                         return json.GetString();
-                    }).recover(context, [] (const Exception &exception) {
+                    }).recover(context, [](const Exception &exception) {
                         // FIXME: throw exception to signal errors (i.e: network error)
                         return "";
                     });
         }
 
-        Future<std::string> TezosLikeBlockchainExplorer::getChainId(const std::shared_ptr<api::ExecutionContext> &context,
-                                                              const std::shared_ptr<HttpClient> &http) {
+        Future<std::string>
+        TezosLikeBlockchainExplorer::getChainId(const std::shared_ptr<api::ExecutionContext> &context,
+                                                const std::shared_ptr<HttpClient> &http) const
+        {
             const bool parseNumbersAsString = true;
             std::unordered_map<std::string, std::string> headers{{"Content-Type", "application/json"}};
             return http->GET(fmt::format("/chains/main/chain_id"),
-                             std::unordered_map<std::string, std::string>{},
-                             getRPCNodeEndpoint())
+                              std::unordered_map<std::string, std::string>{},
+                              getRPCNodeEndpoint())
                     .json(parseNumbersAsString)
                     .map<std::string>(context, [](const HttpRequest::JsonResult &result) {
                         auto &json = *std::get<1>(result);
@@ -198,7 +212,7 @@ namespace ledger {
                             return "";
                         }
                         return json.GetString();
-                    }).recover(context, [] (const Exception &exception) {
+                    }).recover(context, [](const Exception &exception) {
                         return "";
                     });
         }
@@ -206,7 +220,7 @@ namespace ledger {
         Future<std::shared_ptr<GasLimit>> TezosLikeBlockchainExplorer::getEstimatedGasLimit(
             const std::shared_ptr<HttpClient> &http,
             const std::shared_ptr<api::ExecutionContext> &context,
-            const std::shared_ptr<TezosLikeTransactionApi> &tx)
+            const std::shared_ptr<TezosLikeTransactionApi> &tx) const
         {
             return getChainId(context, http).flatMapPtr<GasLimit>(context, [=](const std::string& result)-> FuturePtr<GasLimit> {
                 return getEstimatedGasLimit(http, context, tx, result);
@@ -216,8 +230,8 @@ namespace ledger {
         Future<std::shared_ptr<GasLimit>> TezosLikeBlockchainExplorer::getEstimatedGasLimit(
             const std::shared_ptr<HttpClient> &http,
             const std::shared_ptr<api::ExecutionContext> &context,
-            const std::shared_ptr<TezosLikeTransactionApi> &tx, 
-            const std::string& strChainID)
+            const std::shared_ptr<TezosLikeTransactionApi> &tx,
+            const std::string& strChainID) const
         {
             const auto postPath =
                 fmt::format("/chains/{}/blocks/head/helpers/scripts/run_operation", strChainID);
@@ -264,7 +278,7 @@ namespace ledger {
                                 api::ErrorCode::HTTP_ERROR,
                                 std::make_shared<HttpRequest::JsonResult>(result),
                                 "failed to get operation_result in simulation");
-                            }                           
+                            }
 
                             auto &operationResult = content.GetObject()["metadata"]
                                                     .GetObject()["operation_result"];
@@ -318,92 +332,5 @@ namespace ledger {
                 });
         }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    }
-}
+    } // namespace core
+} // namespace ledger

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
@@ -44,7 +44,7 @@
 #include <utils/ConfigurationMatchable.h>
 #include <utils/Option.hpp>
 #include <wallet/common/Block.h>
-#include <wallet/common/explorers/AbstractBlockchainExplorer.h>
+#include <wallet/common/explorers/AbstractLedgerApiBlockchainExplorer.h>
 #include <wallet/tezos/keychains/TezosLikeKeychain.h>
 #include <api/TezosOperationTag.hpp>
 
@@ -57,8 +57,8 @@ namespace ledger {
                                                          bool isDelegatable = false) :
                     address(a),
                     spendable(isSpendable),
-                    delegatable(isDelegatable) {
-            };
+                    delegatable(isDelegatable)
+            {}
 
             std::string address;
             bool spendable;
@@ -88,26 +88,6 @@ namespace ledger {
                 type = api::TezosOperationTag::OPERATION_TAG_NONE;
                 status = 0;
             }
-
-            TezosLikeBlockchainExplorerTransaction(const TezosLikeBlockchainExplorerTransaction &cpy) {
-                this->hash = cpy.hash;
-                this->receivedAt = cpy.receivedAt;
-                this->value = cpy.value;
-                this->fees = cpy.fees;
-                this->gas_limit = cpy.gas_limit;
-                this->storage_limit = cpy.storage_limit;
-                this->receiver = cpy.receiver;
-                this->sender = cpy.sender;
-                this->block = cpy.block;
-                this->confirmations = cpy.confirmations;
-                this->type = cpy.type;
-                this->publicKey = cpy.publicKey;
-                this->originatedAccount = cpy.originatedAccount;
-                this->status = cpy.status;
-                this->originatedAccountUid = cpy.originatedAccountUid; 
-                this->originatedAccountAddress = cpy.originatedAccountAddress; 
-            }
-
         };
 
         struct GasLimit {
@@ -121,56 +101,94 @@ namespace ledger {
                 reveal(r), transaction(t) {}
         };
 
+        struct TezosLikeBlchainExplorerTransactionsBulk {
+            std::vector<TezosLikeBlockchainExplorerTransaction> transactions;
+            bool hasNext{false};
+        };
+
+
+        class TezosLikeTransactionsParser;
+        class TezosLikeTransactionsBulkParser;
+        class TezosLikeBlockParser;
+
+        using TezosLikeLedgerApiBlockchainExplorer = AbstractLedgerApiBlockchainExplorer<
+                TezosLikeBlockchainExplorerTransaction,
+                TezosLikeBlchainExplorerTransactionsBulk,
+                TezosLikeTransactionsParser,
+                TezosLikeTransactionsBulkParser,
+                TezosLikeBlockParser,
+                api::TezosLikeNetworkParameters>;
+
         class TezosLikeTransactionApi;
-        class TezosLikeBlockchainExplorer : public ConfigurationMatchable,
-                                            public AbstractBlockchainExplorer<TezosLikeBlockchainExplorerTransaction> {
+        class TezosLikeBlockchainExplorer : protected TezosLikeLedgerApiBlockchainExplorer,
+                                            public ConfigurationMatchable,
+                                            public DedicatedContext
+        {
         public:
-            typedef ledger::core::Block Block;
+            using Block = ledger::core::Block;
             using Transaction = TezosLikeBlockchainExplorerTransaction;
+            using TransactionsBulk = TezosLikeBlchainExplorerTransactionsBulk;
 
-            TezosLikeBlockchainExplorer(const std::shared_ptr<ledger::core::api::DynamicObject> &configuration,
-                                        const std::vector<std::string> &matchableKeys);
+            TezosLikeBlockchainExplorer(
+                const std::shared_ptr<api::ExecutionContext> &context,
+                const std::shared_ptr<HttpClient> &http,
+                const api::TezosLikeNetworkParameters &parameters,
+                const std::shared_ptr<ledger::core::api::DynamicObject> &configuration,
+                const std::vector<std::string> &matchableKeys);
 
             virtual Future<std::shared_ptr<BigInt>>
-            getBalance(const std::vector<TezosLikeKeychain::Address> &addresses) = 0;
+            getBalance(const TezosLikeKeychain::Address &address) const = 0;
 
             virtual Future<std::shared_ptr<BigInt>>
-            getFees() = 0;
+            getFees() const = 0;
 
             /// Return the gas Price of the last block in picotez (e-12) per gas
             virtual Future<std::shared_ptr<BigInt>>
-            getGasPrice() = 0;
+            getGasPrice() const = 0;
+
+            virtual Future<String>
+            pushTransaction(const std::vector<uint8_t>& transaction) = 0;
+
+            virtual FuturePtr<TransactionsBulk>
+            getTransactions(const std::string& address,
+                            const Either<std::string, uint32_t>& token = {}) const = 0;
+
+            virtual FuturePtr<Block>
+            getCurrentBlock() const = 0;
+
+            virtual FuturePtr<Transaction>
+            getTransactionByHash(const String &transactionHash) const = 0;
 
             virtual Future<std::shared_ptr<BigInt>>
-            getEstimatedGasLimit(const std::string &address) = 0;
+            getEstimatedGasLimit(const std::string &address) const = 0;
 
-            virtual Future<std::shared_ptr<GasLimit>> getEstimatedGasLimit(
-                const std::shared_ptr<TezosLikeTransactionApi> &tx) = 0;
+            virtual Future<std::shared_ptr<GasLimit>>
+            getEstimatedGasLimit(const std::shared_ptr<TezosLikeTransactionApi> &tx) const = 0;
 
             Future<std::shared_ptr<GasLimit>> getEstimatedGasLimit(
                 const std::shared_ptr<HttpClient> &http,
                 const std::shared_ptr<api::ExecutionContext> &context,
-                const std::shared_ptr<TezosLikeTransactionApi> &transaction);
+                const std::shared_ptr<TezosLikeTransactionApi> &transaction) const;
 
             Future<std::shared_ptr<GasLimit>> getEstimatedGasLimit(
                 const std::shared_ptr<HttpClient> &http,
                 const std::shared_ptr<api::ExecutionContext> &context,
                 const std::shared_ptr<TezosLikeTransactionApi> &transaction,
-                const std::string &chainId);
+                const std::string &chainId) const;
 
 
             Future<std::string> getChainId(
                 const std::shared_ptr<api::ExecutionContext> &context,
-                const std::shared_ptr<HttpClient> &http);
+                const std::shared_ptr<HttpClient> &http) const;
 
 
             virtual Future<std::shared_ptr<BigInt>>
-            getStorage(const std::string &address) = 0;
+            getStorage(const std::string &address) const = 0;
 
             virtual Future<std::shared_ptr<BigInt>>
-            getCounter(const std::string &address) = 0;
+            getCounter(const std::string &address) const = 0;
 
-            virtual Future<std::vector<uint8_t>> forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx) = 0;
+            virtual Future<std::vector<uint8_t>> forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx) const = 0;
             // This a helper to manage legacy KT accounts
             // WARNING: we will only support removing delegation and transfer from KT to implicit account
             static Future<std::vector<uint8_t>> forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx,
@@ -178,7 +196,7 @@ namespace ledger {
                                                                  const std::shared_ptr<HttpClient> &http,
                                                                  const std::string &rpcNode);
 
-            virtual Future<std::string> getManagerKey(const std::string &address) = 0;
+            virtual Future<std::string> getManagerKey(const std::string &address) const = 0;
             // This a helper to manage legacy KT accounts
             // WARNING: we will only support removing delegation and transfer from KT to implicit account
             static Future<std::string> getManagerKey(const std::string &address,
@@ -186,22 +204,22 @@ namespace ledger {
                                                      const std::shared_ptr<HttpClient> &http,
                                                      const std::string &rpcNode);
 
-            virtual Future<bool> isAllocated(const std::string &address) = 0;
+            virtual Future<bool> isAllocated(const std::string &address) const = 0;
             static Future<bool> isAllocated(const std::string &address,
                                             const std::shared_ptr<api::ExecutionContext> &context,
                                             const std::shared_ptr<HttpClient> &http,
                                             const std::string &rpcNode);
 
-            virtual Future<std::string> getCurrentDelegate(const std::string &address) = 0;
+            virtual Future<std::string> getCurrentDelegate(const std::string &address) const = 0;
             static Future<std::string> getCurrentDelegate(const std::string &address,
                                                           const std::shared_ptr<api::ExecutionContext> &context,
                                                           const std::shared_ptr<HttpClient> &http,
                                                           const std::string &rpcNode);
 
             /// Check that the account is funded.
-            virtual Future<bool> isFunded(const std::string &address) = 0;
+            virtual Future<bool> isFunded(const std::string &address) const = 0;
 
-            virtual Future<bool> isDelegate(const std::string &address) = 0;
+            virtual Future<bool> isDelegate(const std::string &address) const = 0;
 
             /// Get a token balance for an account
             virtual Future<std::shared_ptr<BigInt>>
@@ -209,12 +227,24 @@ namespace ledger {
                             const std::string& tokenAddress) const = 0;
 
         protected:
-            std::string getRPCNodeEndpoint() const {
+            inline const std::string& getRPCNodeEndpoint() const {
                 return _rpcNode;
-            };
+            }
+
+            inline api::TezosLikeNetworkParameters getNetworkParameters() const override {
+                return _parameters;
+            }
+
+            inline std::shared_ptr<api::ExecutionContext> getExplorerContext() const override {
+                return getContext();
+            }
+
         private:
             std::string _rpcNode;
+            api::TezosLikeNetworkParameters _parameters;
         };
-    }
-}
+
+    } // namespace core
+} // namespace ledger
+
 #endif //LEDGER_CORE_TEZOSLIKEBLOCKCHAINEXPLORER_H

--- a/core/src/wallet/tezos/synchronizers/TezosLikeAccountSynchronizer.cpp
+++ b/core/src/wallet/tezos/synchronizers/TezosLikeAccountSynchronizer.cpp
@@ -180,7 +180,7 @@ auto TezosLikeAccountSynchronizer::synchronizeTransactions(
         }
         return std::string("");
     }();
-    return _explorer->getTransactions({address}, std::to_string(state.offset))
+    return _explorer->getTransactions({address}, state.offset)
         .flatMap<uint32_t>(
             _account->getContext(),
             [this, address, state, uid, nbTxns](


### PR DESCRIPTION
- Remove some unused code
- Use single address instead of vector of addresses in explorer endpoints
- Remove sessions mechanism from TezosLikeBlockchainExplorer